### PR TITLE
Updated font weight of post title and tags back to 600

### DIFF
--- a/components/PostsFeed.vue
+++ b/components/PostsFeed.vue
@@ -254,7 +254,7 @@ section {
 }
 
 .postTitle {
-  font-weight: $medium;
+  font-weight: $bold;
   font-size: 1.75rem;
   margin: 1rem 0;
 
@@ -278,7 +278,7 @@ section {
 .postTags {
   text-transform: uppercase;
   font-size: 1rem;
-  font-weight: $medium;
+  font-weight: $bold;
   margin: 0;
 
   @media (min-width: $bp-desktop) {


### PR DESCRIPTION
I think you changed this to font-weight 400 last week because it didn't fit the original design on Adobe XD. These changes were requests from Marta's design feedback notes last month. Just changing it back quickly.

![image](https://user-images.githubusercontent.com/12984263/91728257-d6278480-eb70-11ea-93e1-63a37169a810.png)
