### PR TITLE
Made SuggestedPosts inclusive

### DIFF
--- a/pages/post/_slug.vue
+++ b/pages/post/_slug.vue
@@ -10,9 +10,9 @@
     <ArtistCredits :artists="post.artist" />
     <SocialShare :title="post.title" link="" />
     <SuggestedPosts
-      :city="{ name: city, filterType: 'exclude' }"
-      :sense="{ name: sense, filterType: 'exclude' }"
-      :mood="{ name: mood, filterType: 'exclude' }"
+      :included-cities="cities"
+      :included-senses="senses"
+      :included-mood="mood"
     />
     <Footer />
   </div>
@@ -76,11 +76,11 @@ export default {
         content: content.raw.children,
       }
     },
-    city() {
-      return this.post.city[0] ? this.post.city[0].name : ""
+    cities() {
+      return this.post.city.map((city) => city.name)
     },
-    sense() {
-      return this.post.sense[0] ? this.post.sense[0].name : ""
+    senses() {
+      return this.post.sense.map((sense) => sense.name)
     },
     mood() {
       return this.post.mood ? this.post.mood.mood : ""


### PR DESCRIPTION
Instead of using AND logic (each category must fit certain criteria), this change makes `SuggestedPosts` use OR logic. As long as a post matches at least 1 category item (any city, any sense, any mood) of the current post, it will show up in the list.

Example:

![screencapture-localhost-3000-post-shayan-sajadian-1600528934745](https://user-images.githubusercontent.com/12984263/93670588-69feb900-fa6a-11ea-98a3-5f43ccbb34c7.png)
